### PR TITLE
fix: require handlebar file names processed by hbs2ui5 tool to end with the '.hbs' extension

### DIFF
--- a/packages/tools/lib/hbs2ui5/index.js
+++ b/packages/tools/lib/hbs2ui5/index.js
@@ -24,7 +24,7 @@ const onError = (place) => {
 	console.log(`A problem occoured when reading ${place}. Please recheck passed parameters.`);
 };
 
-const isHandlebars = (fileName) => fileName.indexOf('.hbs') !== -1;
+const isHandlebars = (fileName) => fileName.endsWith('.hbs');
 
 const hasTypes = (file, componentName) => {
 	const tsFile = path.join(path.dirname(file), componentName + ".ts")


### PR DESCRIPTION
**fix**: require handlebar file names processed by hbs2ui5  to end with the '.hbs' extension, rather than have '.hbs' exist anywhere within the file names, so that when tools like VIM create temporary '.hbs.swp' files (when editing the corresponding '.hbs' files in VIM), those temporary files aren't used as actual handlebar files by the hbs2ui5.js tool.

**Thank you for your contribution!** 👏


### PR checklist
- [X] Check the [Development Hints](https://sap.github.io/ui5-webcomponents/docs/contributing/DoD/)

- [X] Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [X] Add proper description about the background of the change and the change itself

- [ ] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [ ] Read the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
